### PR TITLE
Update wording in 'account not registered' message

### DIFF
--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -16,7 +16,7 @@
                 <img src="loader.svg"/>
                 <div class="ide-page-loader-text">
                     <p id="loading-crw-text" style="display: none">Loading CodeReady Workspaces...</p>
-                    <p id="register-developer-sandbox-text" style="display: none">Please, register the <a href="https://developers.redhat.com/developer-sandbox/ide">Developer Sandbox</a> for Red Hat OpenShift account...</p>
+                    <p id="register-developer-sandbox-text" style="display: none">To use CodeReady Workspaces, please register a <a href="https://developers.redhat.com/developer-sandbox/ide">Developer Sandbox</a> for Red Hat OpenShift account.</p>
                     <p id="verify-account-text" style="display: none">The account is not verified.<br> Please, verify the account on the <a href="https://developers.redhat.com/developer-sandbox/ide">Developer Sandbox</a> for Red Hat OpenShift registration page.</p>
                     <p id="error-text" style="display: none">Error occurred ¯\_(ツ)_/¯<br> Please, contact <a href="mailto:devsandbox@redhat.com">devsandbox@redhat.com</a> for assistance.</p>
                     <p id="error-status"style="display: none; color: #ef2929;"></p>


### PR DESCRIPTION
Improve wording of message shown when e.g. an account has been deactivated and needs reactivation.